### PR TITLE
Add sphinx API docs for gh-pages

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,58 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# http://www.sphinx-doc.org/en/master/config
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("../python/"))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'Evaluation Tools'
+copyright = '2020, Jason Regina and Austin Raney'
+author = 'Jason Regina and Austin Raney'
+
+# The full version, including alpha/beta/rc tags
+release = '1.0.0'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+        "sphinx.ext.autodoc", "sphinx.ext.napoleon"
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+# html_theme = 'alabaster'
+html_theme = 'furo'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/docs/evaluation_tools._restclient.rst
+++ b/docs/evaluation_tools._restclient.rst
@@ -1,0 +1,8 @@
+evaluation\_tools.\_restclient subpackage
+=========================================
+
+.. automodule:: evaluation_tools._restclient._restclient
+   :members:
+   :undoc-members:
+   :show-inheritance:
+

--- a/docs/evaluation_tools.nwis_client.rst
+++ b/docs/evaluation_tools.nwis_client.rst
@@ -1,0 +1,8 @@
+evaluation\_tools.nwis\_client subpackage
+=========================================
+
+.. automodule:: evaluation_tools.nwis_client.iv
+   :members:
+   :undoc-members:
+   :show-inheritance:
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,97 @@
+``evaluation_tools``
+=====================
+
+Tools for retrieving hydrological data
+
+.. toctree::
+   :hidden:
+   :maxdepth: 2
+   :caption: API:
+
+   evaluation_tools.nwis_client
+   evaluation_tools._restclient
+
+
+Motivation
+----------
+
+We developed evaluation_tools with data scientists in mind. We attempted
+to ensure the simplest methods such as ``get`` both accepted and
+returned data structures frequently used by data scientists using
+scientific Python. Specifically, this means that
+|pandas.DataFrames|_,
+|geopandas.GeoDataFrames|_,
+and
+|numpy.arrays|_
+are the most frequently encountered data structures when using
+evaluation_tools. The majority of methods include sensible defaults that
+cover the majority of use-cases, but allow customization if required.
+
+We also attempted to adhere to organizational (NOAA-OWP) data standards
+where they exist. This means ``pandas.DataFrames`` will contain column
+labels like ``usgs_site_code``, ``start_date``, ``value_date``, and
+``measurement_unit`` which are consistent with organization wide naming
+conventions. Our intent is to make retrieving, evaluating, and exporting
+data as easy and reproducible as possible for scientists, practitioners
+and other hydrological experts.
+
+.. |numpy.arrays| replace:: ``numpy.arrays``
+.. _numpy.arrays: https://numpy.org/doc/stable/reference/arrays.html#array-objects
+.. |geopandas.GeoDataFrames| replace:: ``geopandas.GeoDataFrames``
+.. _geopandas.GeoDataFrames: https://geopandas.readthedocs.io/en/latest/docs/user_guide/data_structures.html#geodataframe
+.. |pandas.DataFrames| replace:: ``pandas.DataFrames``
+.. _pandas.DataFrames: https://pandas.pydata.org/docs/user_guide/dsintro.html#dataframe
+
+What’s here?
+------------
+
+We’ve taken a grab-and-go approach to installation and usage of
+Evaluation tools. This means, in line with a standard toolbox, you will
+typically install just the tool or tools that get your job done without
+having to install all the other tools available. This means a lighter
+installation load and that tools can be added to the toolbox, without
+affecting your workflows!
+
+It should be noted, we commonly refer to individual tools in evaluation
+tools as a subpackage or by their name (e.g. ``nwis_client``). You will
+find this lingo in both issues and documentation.
+
+Currently the repository has the following subpackages:
+
+-  nwis_client: Provides easy to use methods for retrieving data from
+   the `USGS NWIS Instantaneous Values (IV) Web
+   Service <https://waterservices.usgs.gov/rest/IV-Service.html>`__.
+-  \_restclient: A generic REST client with built in cache that make the
+   construction and retrieval of GET requests painless.
+
+Installation
+------------
+
+In accordance with the python community, we support and advise the usage
+of virtual environments in any workflow using python. In the following
+installation guide, we use python’s built-in ``venv`` module to create a
+virtual environment in which the tools will be installed. Note this is
+just personal preference, any python virtual environment manager should
+work just fine (``conda``, ``pipenv``, etc. ).
+
+.. code:: bash
+
+   # Create and activate python environment, requires python >= 3.8
+   $ python3 -m venv venv
+   $ source venv/bin/activate
+   $ python3 -m pip install --upgrade pip
+
+   # Install nwis_client
+   $ python3 -m pip install git+https://github.com/NOAA-OWP/evaluation_tools.git#subdirectory=python/nwis_client
+
+   # Install _restclient
+   $ python3 -m pip install git+https://github.com/NOAA-OWP/evaluation_tools.git#subdirectory=python/_restclient
+
+UTC Time
+--------
+
+Note: the canonical ``pandas.DataFrames`` used by evaluation_tools use
+time-zone naive datetimes that assume UTC time. In general, do not
+assume methods are compatible with time-zone aware datetimes or
+timestamps. Expect methods to transform time-zone aware datetimes and
+timestamps into their timezone naive counterparts at UTC time.

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/notes
+++ b/docs/notes
@@ -1,0 +1,8 @@
+Must use `--implicit-namespaces` w/ sphinx-api doc with namespace packages
+
+Use, to build the package docs:
+sphinx-apidoc --implicit-namespaces -o docs/ python "*test?*"
+
+sphinx-apidoc -P --implicit-namespaces -o . ../python/_restclient/evaluation_tools
+
+sphinx-apidoc -T -P -e --implicit-namespaces -o . ../python/_restclient/evaluation_tools


### PR DESCRIPTION
closes #8 

Adds documentation that can be deployed on a gh-pages branch using `sphinx`. For now, the files are written using restructured text, this is the default for sphinx, but this may change in the future for ease of use purposes.

Documentation can be built using `make html` when in the `/docs` dir. I marked in todos to add deps to reqs, but for now, this requires `sphinx` and `furo` (`furo` is the theme used by sphinx at the moment).

## Additions

- API docs deployable on `gh-pages` branch

## Notes

- In the future, we may want to move to markdown over restructured text for usability sake. 

## Todos

- Deploy on `gh-pages` branch
- Figure out how to embed Jupyter notebooks in documentation (i.e. for examples)
-  Add deps to `requirements.txt`

## Checklist

- [x] PR has an informative and human-readable title
- [x] PR is well outlined and documented. See [#12](https://github.com/jarq6c/evaluation_tools/pull/12) for an example
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: