### PR TITLE
change default site_status to all

### DIFF
--- a/python/nwis_client/evaluation_tools/nwis_client/iv.py
+++ b/python/nwis_client/evaluation_tools/nwis_client/iv.py
@@ -226,7 +226,7 @@ class IVDataService:
             None,
         ] = None,
         period: Union[str, None] = None,
-        siteStatus: str = "active",
+        siteStatus: str = "all",
         **params,
     ):
         # TODO Docstring
@@ -268,7 +268,7 @@ class IVDataService:
             None,
         ] = None,
         period: Union[str, None] = None,
-        siteStatus: str = "active",
+        siteStatus: str = "all",
         max_sites_per_request: int = 100,
         **params,
     ) -> List[requests.Response]:
@@ -300,7 +300,7 @@ class IVDataService:
         period: str, None
             Observation record for period until current time. Uses ISO 8601
             period time.
-        siteStatus: str, optional, default 'active'
+        siteStatus: str, optional, default 'all'
             Site status in string format
         max_sites_per_request: int, optional, default 100
             Generally should not be changed. Maximum number of sites in any single
@@ -385,7 +385,7 @@ class IVDataService:
             None,
         ] = None,
         period: Union[str, None] = None,
-        siteStatus: str = "active",
+        siteStatus: str = "all",
         max_sites_per_request: int = 100,
         **params,
     ):
@@ -429,7 +429,7 @@ class IVDataService:
             None,
         ] = None,
         period: Union[str, None] = None,
-        siteStatus: str = "active",
+        siteStatus: str = "all",
         **params,
     ):
         params.update(
@@ -465,7 +465,7 @@ class IVDataService:
             None,
         ] = None,
         period: Union[str, None] = None,
-        siteStatus: str = "active",
+        siteStatus: str = "all",
         **params,
     ):
         params = self._get_raw_params_handler(
@@ -504,7 +504,7 @@ class IVDataService:
             None,
         ] = None,
         period: Union[str, None] = None,
-        siteStatus: str = "active",
+        siteStatus: str = "all",
         **params,
     ):
         params = self._get_raw_params_handler(
@@ -535,7 +535,7 @@ class IVDataService:
             None,
         ] = None,
         period: Union[str, None] = None,
-        siteStatus: str = "active",
+        siteStatus: str = "all",
         **params,
     ):
         params = self._get_raw_params_handler(
@@ -570,7 +570,7 @@ class IVDataService:
             None,
         ] = None,
         period: Union[str, None] = None,
-        siteStatus: str = "active",
+        siteStatus: str = "all",
         **params,
     ):
         params = self._get_raw_params_handler(

--- a/python/nwis_client/evaluation_tools/nwis_client/iv.py
+++ b/python/nwis_client/evaluation_tools/nwis_client/iv.py
@@ -80,7 +80,7 @@ class IVDataService:
             None,
         ] = None,
         period: Union[str, None] = None,
-        siteStatus: str = "active",
+        siteStatus: str = "all",
         **params,
     ):
         """Return Pandas DataFrame of NWIS IV data.
@@ -108,7 +108,7 @@ class IVDataService:
         period: str, None
             Observation record for period until current time. Uses ISO 8601
             period time.
-        siteStatus: str, optional, default 'active'
+        siteStatus: str, optional, default 'all'
             Site status in string format
         params:
             Additional parameters passed directly to service.

--- a/python/nwis_client/setup.py
+++ b/python/nwis_client/setup.py
@@ -13,7 +13,7 @@ SUBPACKAGE_NAME = "nwis_client"
 SUBPACKAGE_SLUG = f"{NAMESPACE_PACKAGE_NAME}.{SUBPACKAGE_NAME}"
 
 # Subpackage version
-VERSION = "1.0.0"
+VERSION = "1.1.0"
 
 # Package author information
 AUTHOR = "Austin Raney"


### PR DESCRIPTION
The client defaults to fetching only "active" status gage data.  By default, the NWIS rest API uses "all" as the default parameter.  When retrieving historical data, this causes a bit of a surprise when a gage comes back with no data.

Closes #10 

## Changes

- Change default `site_status` from `active` to `all`

## Checklist

- [x] PR has an informative and human-readable title
- [x] PR is well outlined and documented. See [#12](https://github.com/jarq6c/evaluation_tools/pull/12) for an example
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output) using [numpy docstring](https://numpydoc.readthedocs.io/en/latest/format.html) formatting
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
