### PR TITLE
nwis_client: Return empty df and raise warning when no data returned from nwis

### DIFF
--- a/python/nwis_client/evaluation_tools/nwis_client/iv.py
+++ b/python/nwis_client/evaluation_tools/nwis_client/iv.py
@@ -147,7 +147,15 @@ class IVDataService:
 
             return df
 
-        list_of_frames = map(list_to_df_helper, raw_data)
+        list_of_frames = list(map(list_to_df_helper, raw_data))
+
+        # Empty list. No data was returned in the request
+        if not list_of_frames:
+            import warnings
+
+            warning_message = "No data was returned by the request."
+            warnings.warn(warning_message)
+            return pd.DataFrame(None)
 
         # Concatenate list in single pd.DataFrame
         dfs = pd.concat(list_of_frames, ignore_index=True)

--- a/python/nwis_client/tests/test_nwis.py
+++ b/python/nwis_client/tests/test_nwis.py
@@ -79,6 +79,17 @@ def request_status_setter(status: int = 404):
     return partial(MockRequests, **requests_testable_attributes)
 
 
+def test_get_throw_warning(monkeypatch):
+    def wrapper(*args, **kwargs):
+        return []
+
+    # Monkey patch get_raw method to return []
+    monkeypatch.setattr(IVDataService, "get_raw", wrapper)
+
+    with pytest.warns(UserWarning):
+        assert IVDataService.get(sites="04233255").empty is True
+
+
 @pytest.mark.slow
 def test_get(setup_iv):
     # TODO


### PR DESCRIPTION
Closes #11

## Additions

- Warning is raised when no data is returned from nwis iv rest service.

## Removals

- None

## Changes

- If no data is returned by nwis, return an empty df

## Testing

1. `test_get_throw_warning` added to test added code


## Checklist

- [x] PR has an informative and human-readable title
- [x] PR is well outlined and documented. See [#12](https://github.com/jarq6c/evaluation_tools/pull/12) for an example
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output) using [numpy docstring](https://numpydoc.readthedocs.io/en/latest/format.html) formatting
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
