### PR TITLE
Add Event Detection Subpackage

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,72 @@ print(observations_data.head())
 4 2019-08-01 05:00:00    streamflow       01646500            ft3/s  4170.0        [A]       0
 ```
 
+### Event Detection Example
+```python
+# Import tools to retrieve data and detect events
+from evaluation_tools.nwis_client.iv import IVDataService
+from evaluation_tools.events.event_detection import decomposition as ev
+
+# Use pandas to resample the data
+from pandas import Grouper
+
+# Use a helper function to detect events at multiple sites
+def list_events_helper(mi_series, level, halflife, window):
+    """Reduce multi-index series before applying event detection."""
+    return ev.list_events(mi_series.droplevel(level), halflife, window)
+
+# Retrieve streamflow observations for two sites
+observations = IVDataService.get(
+    sites='02146750,0214676115,09489000', 
+    startDT='2019-10-01', 
+    endDT='2020-09-30'
+    )
+
+# Drop extra columns to be more efficient
+observations = observations[[
+    'usgs_site_code', 
+    'value_date', 
+    'value'
+    ]]
+
+# Check for duplicate time series, keep first by default
+observations = observations.drop_duplicates(
+    subset=['usgs_site_code', 'value_date']
+    )
+
+# Resample to hourly, keep first measurement in each 1-hour bin
+observations = observations.groupby([
+    'usgs_site_code',
+    Grouper(key='value_date', freq='H')
+    ]).first().ffill()
+
+# Detect events
+events = observations['value'].groupby(
+    level='usgs_site_code').apply(
+        list_events_helper, 
+        level='usgs_site_code', 
+        halflife='6H', 
+        window='7D'
+    )
+
+# Print event list    
+print(events)
+
+                                start                 end
+usgs_site_code                                           
+02146750       0  2019-10-13 22:00:00 2019-10-15 04:00:00
+               1  2019-10-16 09:00:00 2019-10-18 02:00:00
+               2  2019-10-19 03:00:00 2019-10-23 19:00:00
+               3  2019-10-27 05:00:00 2019-10-28 18:00:00
+               4  2019-10-30 01:00:00 2019-11-02 18:00:00
+...                               ...                 ...
+09489000       34 2020-09-16 00:00:00 2020-09-16 19:00:00
+               35 2020-09-17 00:00:00 2020-09-17 15:00:00
+               36 2020-09-18 04:00:00 2020-09-18 10:00:00
+               37 2020-09-27 01:00:00 2020-09-27 03:00:00
+               38 2020-09-28 05:00:00 2020-09-28 11:00:00
+```
+
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Evaluation Tools
 
-Tools for retrieving observed hydrological data.
+Tools for retrieving and evaluating hydrological data.
 
 ## Motivation
 
@@ -42,6 +42,7 @@ Currently the repository has the following subpackages:
   Service](https://waterservices.usgs.gov/rest/IV-Service.html).
 - \_restclient: A generic REST client with built in cache that make the construction
   and retrieval of GET requests painless.
+- events: Variety of methods used to perform event-based evaluations of hydrometric time series.
 
 ## UTC Time
 
@@ -161,6 +162,9 @@ $ python3 -m pip install git+https://github.com/NOAA-OWP/evaluation_tools.git#su
 
 # Install _restclient
 $ python3 -m pip install git+https://github.com/NOAA-OWP/evaluation_tools.git#subdirectory=python/_restclient
+
+# Install events
+$ python3 -m pip install git+https://github.com/NOAA-OWP/evaluation_tools.git#subdirectory=python/events
 ```
 
 ## Documentation

--- a/python/events/evaluation_tools/events/event_detection/decomposition.py
+++ b/python/events/evaluation_tools/events/event_detection/decomposition.py
@@ -1,0 +1,168 @@
+"""
+================================
+Event Detection :: Decomposition
+================================
+Use time series decomposition to detect hydroligical events in 
+streamflow time series.
+
+Functions
+---------
+detrend_streamflow
+mark_event_flows
+list_events
+
+"""
+
+import numpy as np
+import pandas as pd
+
+def detrend_streamflow(series, halflife, window, reverse=False) -> pd.Series:
+    """Model the trend in a streamflow time series using a rolling 
+        minimum filter. Remove the trend and residual components.
+        Return the detrended streamflow time series.
+        
+        Parameters
+        ----------
+        series: pandas.Series with a DateTimeIndex, required
+            The original streamflow time series.
+        halflife: float, str, timedelta, required
+            Specifies the decay term for `pandas.Series.ewm.mean`. This filter 
+            is used to smooth over interevent noise and reduce detection 
+            of normal instrument fluctuations as events.
+        window: int, offset, or BaseIndexer subclass, required
+            Size of the moving window for `pandas.Series.rolling.min`.
+            This filter is used to model the trend in `series`.
+        reverse: bool, default False, optional
+            Specifies whether to run the filter in reverse.
+            
+        Returns
+        -------
+        detrended: pandas.Series
+            New streamflow time series with trend removed.
+        
+        """
+    # Flip series values to run filter in reverse
+    if reverse:
+        series = pd.Series(series.values[::-1], 
+            index=series.index)
+
+    # Smooth series
+    smooth = series.ewm(halflife=halflife, times=series.index, 
+        adjust=False).mean()
+    
+    # Estimate a seasonal trend using a rolling minimum
+    trend = smooth.rolling(window=window).min()
+
+    # Remove the seasonal trend
+    detrended = smooth - trend
+
+    # Assume a residual equal to twice the detrended median
+    residual = detrended.median() * 2.0
+
+    # Remove the residual
+    detrended = detrended - residual
+
+    # Eliminate negative values
+    detrended[detrended < 0.0] = 0.0
+
+    # Restore reversed series
+    if reverse:
+        # Return detrended series
+        return pd.Series(detrended.values[::-1], 
+            index=detrended.index)
+
+    # Return detrended series
+    return detrended
+
+def mark_event_flows(series, halflife, window) -> pd.Series:
+    """Model the trend in a streamflow time series by taking the mean
+        of two rolling minimum filters applied in a forward and 
+        backward fashion. Remove the trend and residual components.
+        Return the boolean time series that indicates whether an 
+        individual value in the original streamflow time series
+        is part of an event (True) or not part of an event (False).
+        
+        Parameters
+        ----------
+        series: pandas.Series with a DateTimeIndex, required
+            The original streamflow time series.
+        halflife: float, str, timedelta, required
+            Specifies the decay term for `pandas.Series.ewm.mean`. This filter 
+            is used to smooth over interevent noise and reduce detection 
+            of normal instrument fluctuations as events.
+        window: int, offset, or BaseIndexer subclass, required
+            Size of the moving window for `pandas.Series.rolling.min`.
+            This filter is used to model the trend in `series`.
+            
+        Returns
+        -------
+        event_points: pandas.Series
+            Boolean time series where True indicates the associated value
+            in the `series` is part of an event.
+        
+        """
+    # Detrend with a forward filter
+    forward = detrend_streamflow(series, halflife, window)
+
+    # Detrend with a backward filter
+    backward = detrend_streamflow(series, halflife, window, True)
+
+    # Take the mean of the forward and backward trends
+    detrended = np.mean([forward, backward], axis=0)
+
+    # Assume a residual equal to twice the detrended median
+    residual = np.median(detrended) * 2.0
+
+    # Remove the residual
+    detrended = detrended - residual
+
+    # Eliminate negative values
+    detrended[detrended < 0.0] = 0.0
+
+    # Return mask of non-zero detrended flows
+    return pd.Series((detrended > 0.0), index=series.index)
+
+def list_events(series, halflife, window) -> pd.DataFrame:
+    """Apply time series decomposition to mark event values in a streamflow
+        time series. Discretize continuous event values into indiviual events.
+        Return a DataFrame with one row for each event detected with `start` and 
+        `end` columns indicating the boundaries of each event.
+        
+        Parameters
+        ----------
+        series: pandas.Series with a DateTimeIndex, required
+            The original streamflow time series.
+        halflife: float, str, timedelta, required
+            Specifies the decay term for `pandas.Series.ewm.mean`. This filter 
+            is used to smooth over interevent noise and reduce detection 
+            of normal instrument fluctuations as events.
+        window: int, offset, or BaseIndexer subclass, required
+            Size of the moving window for `pandas.Series.rolling.min`.
+            This filter is used to model the trend in `series`.
+            
+        Returns
+        -------
+        events: pandas.DataFrame
+            A two column DataFrame with a row for each event detected. `start` and 
+            `end` columns indicate the boundaries of each event.
+        
+        """
+    # Detect event flows
+    events = mark_event_flows(series, halflife, window)
+
+    # Identify event starts
+    forward_shift = events.shift(1).fillna(False)
+    starts = (events & ~forward_shift)
+    starts = starts[starts]
+
+    # Identify event ends
+    backward_shift = events.shift(-1).fillna(False)
+    ends = (events & ~backward_shift)
+    ends = ends[ends]
+
+    # Extract times
+    return pd.DataFrame({
+        'start': starts.index,
+        'end': ends.index
+    })
+    

--- a/python/events/evaluation_tools/events/event_detection/decomposition.py
+++ b/python/events/evaluation_tools/events/event_detection/decomposition.py
@@ -3,7 +3,11 @@
 Event Detection :: Decomposition
 ================================
 Use time series decomposition to detect hydroligical events in 
-streamflow time series.
+streamflow time series as described in Regina & Ogden, 2020.
+
+Regina, J.A., F.L. Ogden, 2020.  Automated Correction of Systematic 
+    Errors in High-Frequency Stage Data from V-Notch Weirs using 
+    Time Series Decomposition., Under review., Hydrol. Proc.
 
 Functions
 ---------
@@ -15,10 +19,19 @@ list_events
 
 import numpy as np
 import pandas as pd
+from typing import Union
 
-def detrend_streamflow(series, halflife, window, reverse=False) -> pd.Series:
+def detrend_streamflow(
+    series: pd.Series,
+    halflife: Union[float, str, pd.Timedelta],
+    window: Union[int, pd.offsets, pd.Index],
+    reverse: bool =False
+    ) -> pd.Series:
     """Model the trend in a streamflow time series using a rolling 
-        minimum filter. Remove the trend and residual components.
+        minimum filter. Remove the trend and residual components. The method 
+        aims to produce a detrended time series with a median of 0.0. It assumes 
+        any residual components less than twice the detrended median are random 
+        noise.
         Return the detrended streamflow time series.
         
         Parameters
@@ -74,10 +87,17 @@ def detrend_streamflow(series, halflife, window, reverse=False) -> pd.Series:
     # Return detrended series
     return detrended
 
-def mark_event_flows(series, halflife, window) -> pd.Series:
+def mark_event_flows(
+    series: pd.Series,
+    halflife: Union[float, str, pd.Timedelta],
+    window: Union[int, pd.offsets, pd.Index]
+    ) -> pd.Series:
     """Model the trend in a streamflow time series by taking the mean
         of two rolling minimum filters applied in a forward and 
-        backward fashion. Remove the trend and residual components.
+        backward fashion. Remove the trend and residual components. The method 
+        aims to produce a detrended time series with a median of 0.0. It assumes 
+        any residual components less than twice the detrended median are random 
+        noise.
         Return the boolean time series that indicates whether an 
         individual value in the original streamflow time series
         is part of an event (True) or not part of an event (False).
@@ -122,7 +142,11 @@ def mark_event_flows(series, halflife, window) -> pd.Series:
     # Return mask of non-zero detrended flows
     return pd.Series((detrended > 0.0), index=series.index)
 
-def list_events(series, halflife, window) -> pd.DataFrame:
+def list_events(
+    series: pd.Series,
+    halflife: Union[float, str, pd.Timedelta],
+    window: Union[int, pd.offsets, pd.Index]
+    ) -> pd.DataFrame:
     """Apply time series decomposition to mark event values in a streamflow
         time series. Discretize continuous event values into indiviual events.
         Return a DataFrame with one row for each event detected with `start` and 

--- a/python/events/requirements.txt
+++ b/python/events/requirements.txt
@@ -1,0 +1,6 @@
+numpy==1.19.5
+pandas==1.2.1
+pkg-resources==0.0.0
+python-dateutil==2.8.1
+pytz==2020.5
+six==1.15.0

--- a/python/events/setup.py
+++ b/python/events/setup.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+from setuptools import setup, find_namespace_packages
+
+# python namespace subpackage
+# this namespace package follows PEP420
+# https://packaging.python.org/guides/packaging-namespace-packages/#native-namespace-packages
+
+NAMESPACE_PACKAGE_NAME = "evaluation_tools"
+SUBPACKAGE_NAME = "events"
+
+# Namespace subpackage slug.
+# Ex: mypkg.a # Where the namespace pkg = `mypkg` and the subpackage = `a`
+SUBPACKAGE_SLUG = f"{NAMESPACE_PACKAGE_NAME}.{SUBPACKAGE_NAME}"
+
+# Subpackage version
+VERSION = "0.1.0"
+
+# Package author information
+AUTHOR = "Jason Regina"
+AUTHOR_EMAIL = "jason.regina@noaa.gov"
+
+# Short sub-package description
+DESCRIPTION = "Various methods to support event-based evaluations."
+
+# Package dependency requirements
+REQUIREMENTS = [
+    "pandas",
+]
+
+setup(
+    name=SUBPACKAGE_SLUG,
+    version=VERSION,
+    author=AUTHOR,
+    author_email=AUTHOR_EMAIL,
+    classifiers=[
+        "",
+    ],
+    description=DESCRIPTION,
+    namespace_packages=[NAMESPACE_PACKAGE_NAME],
+    packages=find_namespace_packages(include=[f"{NAMESPACE_PACKAGE_NAME}.*"]),
+    package_data={},
+    install_requires=REQUIREMENTS,
+)

--- a/python/events/tests/test_decomposition.py
+++ b/python/events/tests/test_decomposition.py
@@ -1,0 +1,31 @@
+import pytest
+from evaluation_tools.events.event_detection import decomposition as ev
+
+def test_list_events():
+    # Create trend
+    t = np.linspace(1.0, 1001.0, 1000)
+    trend = 100.0 * np.exp(-0.002 * t)
+
+    # Create event
+    zero_flows = np.zeros(500)
+    event_flows = 1000.0 * np.exp(-0.004 * t[:500])
+    event_flows = np.concatenate([zero_flows, event_flows])
+
+    # Sum total flow
+    flow = trend + event_flows
+
+    # Create streamflow time series
+    series = pd.Series(
+        flow,
+        index=pd.date_range(
+            start=pd.to_datetime('2018-01-01'),
+            periods=len(t),
+            freq='H'),
+        name='streamflow'
+    )
+
+    # Detect event
+    events = ev.list_events(series, '6H', '7D')
+
+    # Should detect a single event
+    assert len(events.index) == 1

--- a/python/events/tests/test_decomposition.py
+++ b/python/events/tests/test_decomposition.py
@@ -1,6 +1,9 @@
 import pytest
 from evaluation_tools.events.event_detection import decomposition as ev
 
+import pandas as pd
+import numpy as np
+
 def test_list_events():
     # Create trend
     t = np.linspace(1.0, 1001.0, 1000)

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ AUTHOR = "Jason Regina"
 AUTHOR_EMAIL = "jarq6c@gmail.com"
 
 # Namespace package version
-VERSION = "1.0.0"
+VERSION = "1.2.0"
 URL = "https://github.com/NOAA-OWP/evaluation_tools"
 
 # Map subpackage namespace to relative location
@@ -31,6 +31,7 @@ SUBPACKAGES = {
     "evaluation_tools.nwis_client": "python/nwis_client",
     "evaluation_tools._restclient": "python/_restclient",
     "evaluation_tools.gcp_client": "python/gcp_client",
+    "evaluation_tools.events": "python/events",
 }
 
 # Short sub-package description


### PR DESCRIPTION
This new subpackage is a more streamlined and simplified version of event detection using time series decomposition as it appears in Regina & Ogden, 2021 (under review).

## Additions

- `evaluation_tools.events.event_detection.decomposition`
- Could be future home of additional event-based analysis methods

## Removals

- None

## Changes

- README.md has been updated to reflect the new subpackage.
- Advanced version to 1.2

## Testing

1. Added single test for `list_events`. Due to the structure of the module, this tests all methods at least once.
2. This test fabricates a streamflow record with a single event and runs event detection to ensure a single event is detected.


## Notes

- As per previous discussions, decomposition requires enough data to intelligently derive a baseflow trend. Time series should probably consist of at least 700 to 1000 values to get reasonable results.
- This version has two primary parameters (`halflife` and `window`). The is effectively a bandpass filter. These parameters control the upper and lower frequency bounds of the filter. `halflife` is used as part of a weighted smoothing filter to reduce high frequency noise. `window` is used with a rolling minimum filter to model low frequency trend (AKA baseflow) in the streamflow time series (which is then removed).

## Todos

- Method to optionally adjust `start` to local minimum. This is computationally expensive.

## Checklist

- [x] PR has an informative and human-readable title
- [x] PR is well outlined and documented. See [#12](https://github.com/jarq6c/evaluation_tools/pull/12) for an example
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output) using [numpy docstring](https://numpydoc.readthedocs.io/en/latest/format.html) formatting
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
