### PR TITLE
Minor Events Updates

### DIFF
--- a/python/events/evaluation_tools/events/event_detection/decomposition.py
+++ b/python/events/evaluation_tools/events/event_detection/decomposition.py
@@ -92,7 +92,7 @@ def mark_event_flows(
     halflife: Union[float, str, pd.Timedelta],
     window: Union[int, pd.tseries.offsets.DateOffset, pd.Index]
     ) -> pd.Series:
-    """Model the trend in a streamflow time series by taking the mean
+    """Model the trend in a streamflow time series by taking the max
         of two rolling minimum filters applied in a forward and 
         backward fashion. Remove the trend and residual components. The method 
         aims to produce a detrended time series with a median of 0.0. It assumes 
@@ -127,8 +127,8 @@ def mark_event_flows(
     # Detrend with a backward filter
     backward = detrend_streamflow(series, halflife, window, True)
 
-    # Take the mean of the forward and backward trends
-    detrended = np.mean([forward, backward], axis=0)
+    # Take the max of the forward and backward trends
+    detrended = np.maximum(forward, backward)
 
     # Assume a residual equal to twice the detrended median
     residual = np.median(detrended) * 2.0

--- a/python/events/evaluation_tools/events/event_detection/decomposition.py
+++ b/python/events/evaluation_tools/events/event_detection/decomposition.py
@@ -24,7 +24,7 @@ from typing import Union
 def detrend_streamflow(
     series: pd.Series,
     halflife: Union[float, str, pd.Timedelta],
-    window: Union[int, pd.offsets, pd.Index],
+    window: Union[int, pd.tseries.offsets.DateOffset, pd.Index],
     reverse: bool =False
     ) -> pd.Series:
     """Model the trend in a streamflow time series using a rolling 
@@ -90,7 +90,7 @@ def detrend_streamflow(
 def mark_event_flows(
     series: pd.Series,
     halflife: Union[float, str, pd.Timedelta],
-    window: Union[int, pd.offsets, pd.Index]
+    window: Union[int, pd.tseries.offsets.DateOffset, pd.Index]
     ) -> pd.Series:
     """Model the trend in a streamflow time series by taking the mean
         of two rolling minimum filters applied in a forward and 
@@ -145,7 +145,7 @@ def mark_event_flows(
 def list_events(
     series: pd.Series,
     halflife: Union[float, str, pd.Timedelta],
-    window: Union[int, pd.offsets, pd.Index]
+    window: Union[int, pd.tseries.offsets.DateOffset, pd.Index]
     ) -> pd.DataFrame:
     """Apply time series decomposition to mark event values in a streamflow
         time series. Discretize continuous event values into indiviual events.

--- a/python/events/setup.py
+++ b/python/events/setup.py
@@ -13,7 +13,7 @@ SUBPACKAGE_NAME = "events"
 SUBPACKAGE_SLUG = f"{NAMESPACE_PACKAGE_NAME}.{SUBPACKAGE_NAME}"
 
 # Subpackage version
-VERSION = "0.1.0"
+VERSION = "0.2.1"
 
 # Package author information
 AUTHOR = "Jason Regina"


### PR DESCRIPTION
Tweaks `event_detection.decomposition` method. The original method cited (Regina & Ogden, 2020) used the maximum of the forward and backward rolling minimums. This doesn't have a huge effect on the number of events detected, but does tend to result in more slightly accurate start times because the maximum makes the trend "snap" to the input streamflow hydrograph.

The accuracy of event boundaries is still subject to overall signal and event characteristics.

## Additions

- None

## Removals

- None

## Changes

- Uses maximum of forward and backward rolling minimums instead of mean.
- Updated type hints (`typing` did not like `pandas.offsets`)
- Version 0.2.1

## Testing

1. Passes existing test.


## Notes

- None

## Todos

- None

## Checklist

- [x] PR has an informative and human-readable title
- [x] PR is well outlined and documented. See [#12](https://github.com/jarq6c/evaluation_tools/pull/12) for an example
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output) using [numpy docstring](https://numpydoc.readthedocs.io/en/latest/format.html) formatting
- [ ] Placeholder code is flagged / future todos are captured in comments
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
