### PR TITLE
Add github action that runs unit tests

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -1,0 +1,28 @@
+name: Run Unit Tests
+
+on: [push, pull_request]
+
+jobs:
+  unittests:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip pytest coverage coverage-badge
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        python -m pip install -e .
+    - name: Run all unittests 
+      run: |
+        coverage run -m pytest -s python/


### PR DESCRIPTION
Closes  #17

## Additions

- GH action that runs unit tests via `pytest` and `coverage`

## Notes

- Using `coverage` to run the tests so in the future it will be easy to add a coverage badge.

## Todos

- Create `coverage` badge and `gh-badge` branch.

## Checklist

- [x] PR has an informative and human-readable title
- [x] PR is well outlined and documented. See [#12](https://github.com/jarq6c/evaluation_tools/pull/12) for an example
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
