### PR TITLE
gh-pages CI deployment

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -1,0 +1,37 @@
+name: Deploy gh-pages
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build-and-deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip Sphinx furo
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        python -m pip install -e .
+    - name: Build Sphinx documentation
+      run: |
+        cd docs/
+        make html
+        git checkout --track origin/gh-pages 
+        rsync -ac _build/html/ ../
+        cd ..
+        rm -rf docs
+        git config user.name "github-actions"
+        git config user.email "github-actions@github.com"
+        git add -A
+        git commit -m "Deploy gh-pages"
+        git push origin gh-pages


### PR DESCRIPTION
Add a gh-action that automatically builds and deploys documentation to `gh-pages` when something is pushed to the main branch.

## Additions

- gh-action for auto deploying gh-pages

## Notes

- I am not 100% sure this will work, so it might be a WIP, just cant really test if it is going to work or not.

## Checklist

- [x] PR has an informative and human-readable title
- [x] PR is well outlined and documented. See [#12](https://github.com/jarq6c/evaluation_tools/pull/12) for an example
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Passes all existing automated tests
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
