### PR TITLE
Fix gh-pages deployment gh-action

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -30,8 +30,10 @@ jobs:
         rsync -ac _build/html/ ../
         cd ..
         rm -rf docs
-        git config user.name "github-actions"
-        git config user.email "github-actions@github.com"
-        git add -A
-        git commit -m "Deploy gh-pages"
-        git push origin gh-pages
+        if [[ $(git status --porcelain | wc -l) -gt 0 ]]; then
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add -A
+          git commit -m "Deploy gh-pages"
+          git push origin gh-pages
+        fi


### PR DESCRIPTION
Fix bug causing gh-page gh-action to fail. This is caused by `git push origin gh-pages` failing when nothing has been committed.

## Checklist

- [x] PR has an informative and human-readable title
- [x] PR is well outlined and documented. See [#12](https://github.com/jarq6c/evaluation_tools/pull/12) for an example
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
