### PR TITLE
Fix incorrect logic in compute_contingency_table

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,8 +203,8 @@ print('Threat Score: {:.2f}'.format(TS))
 Contingency Table Components
 ============================
 true_positive      148
-false_positive     194
-false_negative       0
+false_positive       0
+false_negative     194
 true_negative     1123
 dtype: int64
 Threat Score: 0.43

--- a/python/metrics/evaluation_tools/metrics/metrics.py
+++ b/python/metrics/evaluation_tools/metrics/metrics.py
@@ -62,8 +62,8 @@ def compute_contingency_table(
     # Reformat
     return pd.Series({
         true_positive_key : ctab.loc[True, True],
-        false_positive_key : ctab.loc[True, False],
-        false_negative_key : ctab.loc[False, True],
+        false_positive_key : ctab.loc[False, True],
+        false_negative_key : ctab.loc[True, False],
         true_negative_key : ctab.loc[False, False]
         })
 

--- a/python/metrics/setup.py
+++ b/python/metrics/setup.py
@@ -13,7 +13,7 @@ SUBPACKAGE_NAME = "metrics"
 SUBPACKAGE_SLUG = f"{NAMESPACE_PACKAGE_NAME}.{SUBPACKAGE_NAME}"
 
 # Subpackage version
-VERSION = "0.1.0"
+VERSION = "0.1.1"
 
 # Package author information
 AUTHOR = "Jason Regina"

--- a/python/metrics/tests/test_metrics.py
+++ b/python/metrics/tests/test_metrics.py
@@ -19,9 +19,9 @@ alt_contigency_table = {
 }
 
 def test_compute_contingency_table():
-    obs = pd.Categorical([True, True, True, False, False, False, 
+    obs = pd.Categorical([True, False, False, True, True, True,
         False, False, False, False])
-    sim = pd.Categorical([True, False, False, True, True, True, 
+    sim = pd.Categorical([True, True, True, False, False, False, 
         False, False, False, False])
 
     table = metrics.compute_contingency_table(obs, sim)


### PR DESCRIPTION
Internal development revealed a logical error in `evaluation_tools.metrics.compute_contigency_table`. This fixes that and updates the unit test.

## Additions

- None

## Removals

- None

## Changes

- Switch how false positives and false negatives are computed using `crosstab`.

## Testing

1. The unit test that tests `compute_contingency_table` has been updated with corrected categorical test series.


## Notes

- Closes #38 

## Todos

- None

## Checklist

- [x] PR has an informative and human-readable title
- [x] PR is well outlined and documented. See [#12](https://github.com/jarq6c/evaluation_tools/pull/12) for an example
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output) using [numpy docstring](https://numpydoc.readthedocs.io/en/latest/format.html) formatting
- [ ] Placeholder code is flagged / future todos are captured in comments
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
