### PR TITLE
Add optional parameter to filter events using minimum duration

### DIFF
--- a/python/events/evaluation_tools/events/event_detection/decomposition.py
+++ b/python/events/evaluation_tools/events/event_detection/decomposition.py
@@ -125,7 +125,7 @@ def mark_event_flows(
     series: pd.Series,
     halflife: Union[float, str, pd.Timedelta],
     window: Union[int, pd.tseries.offsets.DateOffset, pd.Index],
-    minimum_event_duration: Union[pd.Timedelta, datetime.timedelta, np.timedelta64, str, int] = 0
+    minimum_event_duration: Union[pd.Timedelta, datetime.timedelta, np.timedelta64, str, int] = '0H'
     ) -> pd.Series:
     """Model the trend in a streamflow time series by taking the max
         of two rolling minimum filters applied in a forward and 
@@ -148,7 +148,7 @@ def mark_event_flows(
         window: int, offset, or BaseIndexer subclass, required
             Size of the moving window for `pandas.Series.rolling.min`.
             This filter is used to model the trend in `series`.
-        minimum_event_duration: pandas.Timedelta, datetime.timedelta, numpy.timedelta64, str, int, optional, default 0
+        minimum_event_duration: pandas.Timedelta, datetime.timedelta, numpy.timedelta64, str, int, optional, default '0H'
             Enforce a minimum event duration. This should generally be set equal to 
             halflife to reduce the number of false positives flagged as events.
             
@@ -181,7 +181,8 @@ def mark_event_flows(
     event_points = pd.Series((detrended > 0.0), index=series.index)
 
     # Do not filter events
-    if minimum_event_duration == 0:
+    minimum_event_duration = pd.Timedelta(minimum_event_duration)
+    if minimum_event_duration == pd.Timedelta(0):
         # Return mask of non-zero detrended flows
         return event_points
 
@@ -192,7 +193,7 @@ def mark_event_flows(
     durations = events['end'].sub(events['start'])
 
     # Filter events
-    events = events[durations >= pd.Timedelta(minimum_event_duration)].reset_index(drop=True)
+    events = events[durations >= minimum_event_duration].reset_index(drop=True)
     
     # Refine event points
     filtered_event_points = pd.Series(data=False, index=event_points.index)
@@ -206,7 +207,7 @@ def list_events(
     series: pd.Series,
     halflife: Union[float, str, pd.Timedelta],
     window: Union[int, pd.tseries.offsets.DateOffset, pd.Index],
-    minimum_event_duration: Union[pd.Timedelta, datetime.timedelta, np.timedelta64, str, int] = 0
+    minimum_event_duration: Union[pd.Timedelta, datetime.timedelta, np.timedelta64, str, int] = '0H'
     ) -> pd.DataFrame:
     """Apply time series decomposition to mark event values in a streamflow
         time series. Discretize continuous event values into indiviual events.
@@ -224,7 +225,7 @@ def list_events(
         window: int, offset, or BaseIndexer subclass, required
             Size of the moving window for `pandas.Series.rolling.min`.
             This filter is used to model the trend in `series`.
-        minimum_event_duration: pandas.Timedelta, datetime.timedelta, numpy.timedelta64, str, int, optional, default 0
+        minimum_event_duration: pandas.Timedelta, datetime.timedelta, numpy.timedelta64, str, int, optional, default '0H'
             Enforce a minimum event duration. This should generally be set equal to 
             halflife to reduce the number of false positives flagged as events.
             

--- a/python/events/evaluation_tools/events/event_detection/decomposition.py
+++ b/python/events/evaluation_tools/events/event_detection/decomposition.py
@@ -196,7 +196,7 @@ def mark_event_flows(
     events = events[durations >= to_offset(minimum_event_duration)].reset_index(drop=True)
     
     # Refine event points
-    event_points = False
+    event_points.loc[:] = False
     for e in events.itertuples():
         event_points.loc[e.start:e.end] = True
     

--- a/python/events/evaluation_tools/events/event_detection/decomposition.py
+++ b/python/events/evaluation_tools/events/event_detection/decomposition.py
@@ -195,12 +195,12 @@ def mark_event_flows(
     events = events[durations >= pd.Timedelta(minimum_event_duration)].reset_index(drop=True)
     
     # Refine event points
-    event_points.loc[:] = False
+    filtered_event_points = pd.Series(data=False, index=event_points.index)
     for e in events.itertuples():
-        event_points.loc[e.start:e.end] = True
+        filtered_event_points.loc[e.start:e.end] = True
     
     # Return filtered event points
-    return event_points
+    return filtered_event_points
 
 def list_events(
     series: pd.Series,

--- a/python/events/setup.py
+++ b/python/events/setup.py
@@ -13,7 +13,7 @@ SUBPACKAGE_NAME = "events"
 SUBPACKAGE_SLUG = f"{NAMESPACE_PACKAGE_NAME}.{SUBPACKAGE_NAME}"
 
 # Subpackage version
-VERSION = "0.2.1"
+VERSION = "0.2.2"
 
 # Package author information
 AUTHOR = "Jason Regina"

--- a/python/events/tests/test_decomposition.py
+++ b/python/events/tests/test_decomposition.py
@@ -32,3 +32,36 @@ def test_list_events():
 
     # Should detect a single event
     assert len(events.index) == 1
+
+def test_list_events_noise():
+    # Create trend
+    t = np.linspace(1.0, 1001.0, 1000)
+    trend = 100.0 * np.exp(-0.002 * t)
+
+    # Create event
+    zero_flows = np.zeros(500)
+    event_flows = 1000.0 * np.exp(-0.004 * t[:500])
+    event_flows = np.concatenate([zero_flows, event_flows])
+
+    # Simulate noise
+    x = np.linspace(0.0, 42*np.pi, 1000)
+    noise = 25.0 * np.sin(x)
+
+    # Sum total flow
+    flow = trend + event_flows + noise
+
+    # Create streamflow time series
+    series = pd.Series(
+        flow,
+        index=pd.date_range(
+            start=pd.to_datetime('2018-01-01'),
+            periods=len(t),
+            freq='H'),
+        name='streamflow'
+    )
+    
+    # Detect event
+    events = ev.list_events(series, '6H', '7D', '6H')
+
+    # Should detect a single event
+    assert len(events.index) == 1


### PR DESCRIPTION
Introduces new optional parameter to filter events based on duration.

## Additions

- New `minimum_event_duration` option for `evaluation_tools.events.event_detection.decomposition` methods

## Removals

- None

## Changes

- Additional optional parameters and documentation

## Testing

1. Added `test_list_events_noise` method that simulates and tests a noisy signal


## Notes

- This is a common post-processing step. These algorithms are prone to false positives

## Todos

- None

## Checklist

- [x] PR has an informative and human-readable title
- [x] PR is well outlined and documented. See [#12](https://github.com/jarq6c/evaluation_tools/pull/12) for an example
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output) using [numpy docstring](https://numpydoc.readthedocs.io/en/latest/format.html) formatting
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
