### PR TITLE
Add option to shift event start times to local minimum

### DIFF
--- a/python/events/evaluation_tools/events/event_detection/decomposition.py
+++ b/python/events/evaluation_tools/events/event_detection/decomposition.py
@@ -121,6 +121,34 @@ def event_boundaries(event_points: pd.Series):
         'end': ends.index
     })
 
+def find_local_minimum(origin, radius, timeseries):
+    """Return Datetime of local minimum value within radius of origin.
+        
+        Parameters
+        ----------
+        origin: pandas.Series index label applicable to timeseries, required
+            The original streamflow time series.
+        radius: pandas.Timedelta, datetime.timedelta, numpy.timedelta64, str, int, required
+            The search radius around origin to look for a minimum value.
+        timseries: pandas.Series with a DateTimeIndex, required
+            The original time series to inspect.
+            
+        Returns
+        -------
+        Index: 
+            Datetime of the minimum value.
+
+    """
+    # Define search radius
+    radius = pd.Timedelta(radius)
+
+    # Define window
+    left = origin - radius
+    right = origin + radius
+
+    # Find index of minimum value
+    return timeseries.loc[left:right].idxmin()
+
 def mark_event_flows(
     series: pd.Series,
     halflife: Union[float, str, pd.Timedelta],

--- a/python/events/evaluation_tools/events/event_detection/decomposition.py
+++ b/python/events/evaluation_tools/events/event_detection/decomposition.py
@@ -121,14 +121,18 @@ def event_boundaries(event_points: pd.Series):
         'end': ends.index
     })
 
-def find_local_minimum(origin, radius, timeseries):
-    """Return Datetime of local minimum value within radius of origin.
+def find_local_minimum(
+    origin: pd.Timestamp,
+    radius: Union[float, str, pd.Timedelta],
+    timeseries: pd.Series
+    ):
+    """Return Datetime of the local minimum value within radius of origin.
         
         Parameters
         ----------
-        origin: pandas.Series index label applicable to timeseries, required
-            The original streamflow time series.
-        radius: pandas.Timedelta, datetime.timedelta, numpy.timedelta64, str, int, required
+        origin: pandas.Timestamp, required
+            The central datetime around which to search.
+        radius: float, str, pd.Timedelta, required
             The search radius around origin to look for a minimum value.
         timseries: pandas.Series with a DateTimeIndex, required
             The original time series to inspect.
@@ -136,9 +140,17 @@ def find_local_minimum(origin, radius, timeseries):
         Returns
         -------
         Index: 
-            Datetime of the minimum value.
+            Datetime of the local minimum value.
 
     """
+    # Check for DatetimeIndex
+    if type(timeseries.index) != pd.DatetimeIndex:
+        raise Exception("timeseries index is not DatetimeIndex")
+
+    # Check origin is in index
+    if origin not in timeseries.index:
+        raise Exception("origin is not in index")
+
     # Define search radius
     radius = pd.Timedelta(radius)
 
@@ -153,7 +165,8 @@ def mark_event_flows(
     series: pd.Series,
     halflife: Union[float, str, pd.Timedelta],
     window: Union[int, pd.tseries.offsets.DateOffset, pd.Index],
-    minimum_event_duration: Union[pd.Timedelta, datetime.timedelta, np.timedelta64, str, int] = '0H'
+    minimum_event_duration: Union[pd.Timedelta, datetime.timedelta, np.timedelta64, str, int] = '0H',
+    start_radius: Union[pd.Timedelta, datetime.timedelta, np.timedelta64, str, int] = '0H'
     ) -> pd.Series:
     """Model the trend in a streamflow time series by taking the max
         of two rolling minimum filters applied in a forward and 
@@ -179,6 +192,10 @@ def mark_event_flows(
         minimum_event_duration: pandas.Timedelta, datetime.timedelta, numpy.timedelta64, str, int, optional, default '0H'
             Enforce a minimum event duration. This should generally be set equal to 
             halflife to reduce the number of false positives flagged as events.
+        start_radius: pandas.Timedelta, datetime.timedelta, numpy.timedelta64, str, int, optional, default '0H'
+            Shift event starts to a local minimum. Phase shifts imparted on the 
+            original signal may advance or delay event start times depending upon how 
+            much smoothing is required to eliminate noise.
             
         Returns
         -------
@@ -210,18 +227,27 @@ def mark_event_flows(
 
     # Do not filter events
     minimum_event_duration = pd.Timedelta(minimum_event_duration)
-    if minimum_event_duration == pd.Timedelta(0):
+    start_radius = pd.Timedelta(start_radius)
+    if (minimum_event_duration == pd.Timedelta(0)) & (start_radius == pd.Timedelta(0)):
         # Return mask of non-zero detrended flows
         return event_points
 
     # Get list of potential events
     events = event_boundaries(event_points)
 
-    # Compute durations
-    durations = events['end'].sub(events['start'])
+    # Filter by duration
+    if minimum_event_duration != pd.Timedelta(0):
+        # Compute duration
+        durations = events['end'].sub(events['start'])
 
-    # Filter events
-    events = events[durations >= minimum_event_duration].reset_index(drop=True)
+        # Filter events
+        events = events[durations >= minimum_event_duration].reset_index(drop=True)
+
+    # Adjust event starts
+    if start_radius != pd.Timedelta(0):
+        # Adjust
+        events['start'] = events['start'].apply(find_local_minimum, 
+            radius=start_radius, timeseries=series)
     
     # Refine event points
     filtered_event_points = pd.Series(data=False, index=event_points.index)
@@ -235,7 +261,8 @@ def list_events(
     series: pd.Series,
     halflife: Union[float, str, pd.Timedelta],
     window: Union[int, pd.tseries.offsets.DateOffset, pd.Index],
-    minimum_event_duration: Union[pd.Timedelta, datetime.timedelta, np.timedelta64, str, int] = '0H'
+    minimum_event_duration: Union[pd.Timedelta, datetime.timedelta, np.timedelta64, str, int] = '0H',
+    start_radius: Union[pd.Timedelta, datetime.timedelta, np.timedelta64, str, int] = '0H'
     ) -> pd.DataFrame:
     """Apply time series decomposition to mark event values in a streamflow
         time series. Discretize continuous event values into indiviual events.
@@ -256,6 +283,10 @@ def list_events(
         minimum_event_duration: pandas.Timedelta, datetime.timedelta, numpy.timedelta64, str, int, optional, default '0H'
             Enforce a minimum event duration. This should generally be set equal to 
             halflife to reduce the number of false positives flagged as events.
+        start_radius: pandas.Timedelta, datetime.timedelta, numpy.timedelta64, str, int, optional, default '0H'
+            Shift event starts to a local minimum. Phase shifts imparted on the 
+            original signal may advance or delay event start times depending upon how 
+            much smoothing is required to eliminate noise.
             
         Returns
         -------
@@ -265,7 +296,8 @@ def list_events(
         
         """
     # Detect event flows
-    event_points = mark_event_flows(series, halflife, window, minimum_event_duration)
+    event_points = mark_event_flows(series, halflife, window, 
+        minimum_event_duration, start_radius)
 
     # Return events
     return event_boundaries(event_points)

--- a/python/events/setup.py
+++ b/python/events/setup.py
@@ -13,7 +13,7 @@ SUBPACKAGE_NAME = "events"
 SUBPACKAGE_SLUG = f"{NAMESPACE_PACKAGE_NAME}.{SUBPACKAGE_NAME}"
 
 # Subpackage version
-VERSION = "0.2.2"
+VERSION = "0.2.3"
 
 # Package author information
 AUTHOR = "Jason Regina"

--- a/python/events/tests/test_decomposition.py
+++ b/python/events/tests/test_decomposition.py
@@ -61,7 +61,10 @@ def test_list_events_noise():
     )
     
     # Detect event
-    events = ev.list_events(series, '6H', '7D', '6H')
+    events = ev.list_events(series, '6H', '7D', '6H', '6H')
 
     # Should detect a single event
     assert len(events.index) == 1
+
+    # Start should have been shifted
+    assert events['start'].iloc[0] == pd.Timestamp("2018-01-21 19:00:00")


### PR DESCRIPTION
Phase shifts imparted by the constituent filters can cause event starts to miss the mark by a significant margin, especially on noisy data. Using this option can help fix that by shifting start times to a local minimum within some search window.

## Additions

- New `start_radius` option

## Removals

- None

## Changes

- Added new option and logic to `mark_event_flows`

## Testing

1. Verifies start is shifted to appropriate index for contrived noisy test event.


## Notes

- Closes #37 

## Todos

- None

## Checklist

- [x] PR has an informative and human-readable title
- [x] PR is well outlined and documented. See [#12](https://github.com/jarq6c/evaluation_tools/pull/12) for an example
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output) using [numpy docstring](https://numpydoc.readthedocs.io/en/latest/format.html) formatting
- [ ] Placeholder code is flagged / future todos are captured in comments
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
