### PR TITLE
Raise exceptions for bad time series index in event detection

### DIFF
--- a/python/events/evaluation_tools/events/event_detection/decomposition.py
+++ b/python/events/evaluation_tools/events/event_detection/decomposition.py
@@ -55,6 +55,16 @@ def detrend_streamflow(
             New streamflow time series with trend removed.
         
         """
+    # Check index
+    if type(series.index) != pd.DatetimeIndex:
+        raise Exception("series index is not DatetimeIndex")
+
+    if not series.index.is_monotonic_increasing:
+        raise Exception("series index is not monotonically increasing")
+
+    if series.index.has_duplicates:
+        raise Exception("series index has duplicate timestamps")
+
     # Flip series values to run filter in reverse
     if reverse:
         series = pd.Series(series.values[::-1], 

--- a/python/events/setup.py
+++ b/python/events/setup.py
@@ -13,7 +13,7 @@ SUBPACKAGE_NAME = "events"
 SUBPACKAGE_SLUG = f"{NAMESPACE_PACKAGE_NAME}.{SUBPACKAGE_NAME}"
 
 # Subpackage version
-VERSION = "0.2.3"
+VERSION = "0.2.4"
 
 # Package author information
 AUTHOR = "Jason Regina"

--- a/python/events/tests/test_decomposition.py
+++ b/python/events/tests/test_decomposition.py
@@ -68,3 +68,76 @@ def test_list_events_noise():
 
     # Start should have been shifted
     assert events['start'].iloc[0] == pd.Timestamp("2018-01-21 19:00:00")
+
+def test_local_minimum_datetime_exception():
+    # Build a series
+    series = pd.Series(
+        data=[i for i in range(10)],
+        index=[i for i in range(10)]
+    )
+
+    # Test local minimum
+    with pytest.raises(Exception):
+        idx = ev.find_local_minimum(
+            pd.Timestamp('2020-01-01 01:00'),
+            '3H',
+            series
+        )
+
+def test_origin_not_idx():
+    # Build a series
+    series = pd.Series(
+        data=[i for i in range(10)],
+        index=pd.date_range(
+            start=pd.to_datetime('2018-01-01'),
+            periods=10,
+            freq='H'),
+        name='streamflow'
+    )
+
+    # Test local minimum
+    with pytest.raises(Exception):
+        idx = ev.find_local_minimum(
+            pd.Timestamp('2020-01-01 01:00'),
+            '3H',
+            series
+        )
+
+def test_bad_time_series_idx():
+    # Not datetime
+    series = pd.Series(
+        data=[i for i in range(5)],
+        index=[i for i in range(5)]
+    )
+    with pytest.raises(Exception):
+        events = ev.list_events(series, '6H', '7D')
+
+    # Not monotonic
+    series = pd.Series(
+        data=[i for i in range(5)],
+        index=[
+            pd.to_datetime('2018-01-01 04:00'),
+            pd.to_datetime('2018-01-01 01:00'),
+            pd.to_datetime('2018-01-01 02:00'),
+            pd.to_datetime('2018-01-01 03:00'),
+            pd.to_datetime('2018-01-01 05:00')
+        ],
+        name='streamflow'
+    )
+    with pytest.raises(Exception):
+        events = ev.list_events(series, '6H', '7D')
+
+    # Duplicated
+    series = pd.Series(
+        data=[i for i in range(5)],
+        index=[
+            pd.to_datetime('2018-01-01 00:00'),
+            pd.to_datetime('2018-01-01 01:00'),
+            pd.to_datetime('2018-01-01 02:00'),
+            pd.to_datetime('2018-01-01 03:00'),
+            pd.to_datetime('2018-01-01 03:00')
+        ],
+        name='streamflow'
+    )
+    with pytest.raises(Exception):
+        events = ev.list_events(series, '6H', '7D')

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ AUTHOR = "Jason Regina"
 AUTHOR_EMAIL = "jarq6c@gmail.com"
 
 # Namespace package version
-VERSION = "1.3.2"
+VERSION = "1.3.3"
 URL = "https://github.com/NOAA-OWP/evaluation_tools"
 
 # Map subpackage namespace to relative location


### PR DESCRIPTION
Adds additional code to validate time series and test exceptions.

## Additions

- Tests for non-duplicated monotonically increasing datetime index

## Removals

- None

## Changes

- `mark_event_flows` and `find_local_minimum` raise exceptions for invalid series

## Testing

1. New tests verify exceptions are raised for bad series


## Notes

- Lower level methods will also catch some of these, but these exceptions make them explicit

## Todos

- None

## Checklist

- [x] PR has an informative and human-readable title
- [x] PR is well outlined and documented. See [#12](https://github.com/jarq6c/evaluation_tools/pull/12) for an example
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output) using [numpy docstring](https://numpydoc.readthedocs.io/en/latest/format.html) formatting
- [ ] Placeholder code is flagged / future todos are captured in comments
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
