### PR TITLE
Ensure filters aren't run on missing data

### DIFF
--- a/python/events/evaluation_tools/events/event_detection/decomposition.py
+++ b/python/events/evaluation_tools/events/event_detection/decomposition.py
@@ -322,8 +322,17 @@ def list_events(
             `end` columns indicate the boundaries of each event.
         
         """
+    missing = series.isnull()
+    #Find all groups of consecutive data
+    #True = 1, False = 0, so a cumulative sum
+    #identifies groups of data (falses)
+    grouper = missing.cumsum()
+    #Drop groups of nan
+    grouper = grouper[ series.notnull() ]
+    #Group the original data based on this cumulative sum
+    groups = series.groupby(grouper)
     # Detect event flows
-    event_points = mark_event_flows(series, halflife, window, 
+    event_points = groups.apply( mark_event_flows, halflife, window,
         minimum_event_duration, start_radius)
 
     # Return events


### PR DESCRIPTION
Related to #51, here is one way of potentially handling inputs that do contain NaN.  This makes no interpolation assumptions, but simply only marks events continuous chunks of the input series.

## Additions

- Add handling of NaN in `list_events` input series

## Testing

1. All existing tests pass
2. An additional test with missing data should probably be added

## Todos

- Add  test case for series with missing data

## Checklist

- [x] PR has an informative and human-readable title
- [x] PR is well outlined and documented. See [#12](https://github.com/jarq6c/evaluation_tools/pull/12) for an example
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output) using [numpy docstring](https://numpydoc.readthedocs.io/en/latest/format.html) formatting
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
