### PR TITLE
Update contribution guide to reflect usage of pyproject.toml

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,10 +109,11 @@ python
    │       └── foo.py
    │       └── bar.py
    ├── setup.py
+   ├── pyproject.toml
    └── tests/
 ```
 
-3. The packages `setup.py` should use the following template:
+3. The package's `setup.py` should use the following template:
 
 ```python
 #!/usr/bin/env python3
@@ -157,7 +158,20 @@ setup(
 )
 ```
 
-4. The _package_ level (not subpackage) `setup.py` dictionary `SUBPACKAGES`
+4. The package's `pyproject.toml` should use the following template and add any
+build-system requirements:
+
+```
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = [
+  "setuptools>=42",
+  "wheel",
+]
+
+```
+
+5. The _package_ level (not subpackage) `setup.py` dictionary `SUBPACKAGES`
 should be updated to include the subpackage slug (i.e.
 `evaluation_tools.my_subpackage`) and the relative path to the subpackage
 (i.e. `python/my_subpackage`).


### PR DESCRIPTION
## Additions

- Include expected usage of `pyproject.toml` in `CONTRIBUTING.md`.

## Checklist

- [x] PR has an informative and human-readable title
- [x] PR is well outlined and documented. See [#12](https://github.com/jarq6c/evaluation_tools/pull/12) for an example
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output) using [numpy docstring](https://numpydoc.readthedocs.io/en/latest/format.html) formatting
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: