### PR TITLE
Add MSE and NSE methods to metrics subpackage

### DIFF
--- a/python/metrics/evaluation_tools/metrics/metrics.py
+++ b/python/metrics/evaluation_tools/metrics/metrics.py
@@ -25,37 +25,75 @@ Functions
 """
 
 import numpy as np
+import numpy.typing as npt
 import pandas as pd
 from typing import Union
 
 def mean_squared_error(
-    y_true,
-    y_pred,
-    root=False
-    ):
-    """MSE"""
+    y_true: npt.ArrayLike,
+    y_pred: npt.ArrayLike,
+    root: bool = False
+    ) -> float:
+    """Compute the mean squared error, or optionally root mean squared error.
+        
+    Parameters
+    ----------
+    y_true: array-like of shape (n_samples,) or (n_samples, n_outputs)
+        Ground truth (correct) target values, also called observations, measurements, or observed values.
+    y_pred: pandas.Series, required
+        Estimated target values, also called simulations or modeled values.
+    root: bool, default False
+        When True, return the root mean squared error.
+        
+    Returns
+    -------
+    error: float
+        Mean squared error or root mean squared error.
+    
+    """
+    # Compute mean squared error
     MSE = np.sum(np.subtract(y_true, y_pred) ** 2.0) / len(y_true)
 
+    # Return MSE, optionally return root mean squared error
     if root:
         return np.sqrt(MSE)
     return MSE
 
 def nash_sutcliffe_efficiency(
-    y_true,
-    y_pred,
-    log=False,
-    normalized=False
-    ):
-    """NSE
-
+    y_true: npt.ArrayLike,
+    y_pred: npt.ArrayLike,
+    log: bool = False,
+    normalized: bool = False
+    ) -> float:
+    """Compute the Nash–Sutcliffe model efficiency coefficient (NSE), also called the 
+    mean squared error skill score or the R^2 (coefficient of determination) regression score.
+        
+    Parameters
+    ----------
+    y_true: array-like of shape (n_samples,) or (n_samples, n_outputs)
+        Ground truth (correct) target values, also called observations, measurements, or observed values.
+    y_pred: pandas.Series, required
+        Estimated target values, also called simulations or modeled values.
+    log: bool, default False
+        When True, take the log of y_true and y_pred before computing the NSE.
+    normalized: bool, default False
+        When True, normalize the final NSE value using the method from 
+        Nossent & Bauwens, 2012.
+        
+    Returns
+    -------
+    score: float
+        Nash–Sutcliffe model efficiency coefficient
+        
+    References
+    ----------
     Nash, J. E., & Sutcliffe, J. V. (1970). River flow forecasting through 
-    conceptual models part I—A discussion of principles. Journal of 
-    hydrology, 10(3), 282-290.
-
+        conceptual models part I—A discussion of principles. Journal of 
+        hydrology, 10(3), 282-290.
     Nossent, J., & Bauwens, W. (2012, April). Application of a normalized 
-    Nash-Sutcliffe efficiency to improve the accuracy of the Sobol' 
-    sensitivity analysis of a hydrological model. In EGU General Assembly 
-    Conference Abstracts (p. 237).
+        Nash-Sutcliffe efficiency to improve the accuracy of the Sobol' 
+        sensitivity analysis of a hydrological model. In EGU General Assembly 
+        Conference Abstracts (p. 237).
     
     """
     # Optionally transform components
@@ -85,9 +123,9 @@ def compute_contingency_table(
     Parameters
     ----------
     observed: pandas.Series, required
-        pandas.Series of boolean pandas.Categorical values indicating observed occurences
+        pandas.Series of boolean pandas.Categorical values indicating observed occurrences
     simulated: pandas.Series, required
-        pandas.Series of boolean pandas.Categorical values indicating simulated occurences
+        pandas.Series of boolean pandas.Categorical values indicating simulated occurrences
     true_positive_key: str, optional, default 'true_positive'
         Label to use for true positives.
     false_positive_key: str, optional, default 'false_positive'

--- a/python/metrics/evaluation_tools/metrics/metrics.py
+++ b/python/metrics/evaluation_tools/metrics/metrics.py
@@ -19,11 +19,58 @@ Functions
  - percent_correct
  - base_chance
  - equitable_threat_score
+ - mean_squared_error
+ - nash_sutcliffe_efficiency
 
 """
 
+import numpy as np
 import pandas as pd
 from typing import Union
+
+def mean_squared_error(
+    y_true,
+    y_pred,
+    root=False
+    ):
+    """MSE"""
+    MSE = np.sum(np.subtract(y_true, y_pred) ** 2.0) / len(y_true)
+
+    if root:
+        return np.sqrt(MSE)
+    return MSE
+
+def nash_sutcliffe_efficiency(
+    y_true,
+    y_pred,
+    log=False,
+    normalized=False
+    ):
+    """NSE
+
+    Nash, J. E., & Sutcliffe, J. V. (1970). River flow forecasting through 
+    conceptual models part I—A discussion of principles. Journal of 
+    hydrology, 10(3), 282-290.
+
+    Nossent, J., & Bauwens, W. (2012, April). Application of a normalized 
+    Nash-Sutcliffe efficiency to improve the accuracy of the Sobol' 
+    sensitivity analysis of a hydrological model. In EGU General Assembly 
+    Conference Abstracts (p. 237).
+    
+    """
+    # Optionally transform components
+    if log:
+        y_true = np.log(y_true)
+        y_pred = np.log(y_pred)
+
+    # Compute components
+    numerator = mean_squared_error(y_true, y_pred)
+    denominator = mean_squared_error(y_true, np.mean(y_true))
+
+    # Compute score, optionally normalize
+    if normalized:
+        return 1.0 / (1.0 + numerator/denominator)
+    return 1.0 - numerator/denominator
 
 def compute_contingency_table(
     observed: pd.Series,

--- a/python/metrics/evaluation_tools/metrics/metrics.py
+++ b/python/metrics/evaluation_tools/metrics/metrics.py
@@ -75,7 +75,8 @@ def nash_sutcliffe_efficiency(
     y_pred: pandas.Series, required
         Estimated target values, also called simulations or modeled values.
     log: bool, default False
-        When True, take the log of y_true and y_pred before computing the NSE.
+        Apply numpy.log (natural logarithm) to y_true and y_pred 
+        before computing the NSE.
     normalized: bool, default False
         When True, normalize the final NSE value using the method from 
         Nossent & Bauwens, 2012.

--- a/python/metrics/setup.py
+++ b/python/metrics/setup.py
@@ -13,7 +13,7 @@ SUBPACKAGE_NAME = "metrics"
 SUBPACKAGE_SLUG = f"{NAMESPACE_PACKAGE_NAME}.{SUBPACKAGE_NAME}"
 
 # Subpackage version
-VERSION = "0.1.1+1"
+VERSION = "0.1.2+1"
 
 # Package author information
 AUTHOR = "Jason Regina"

--- a/python/metrics/tests/test_metrics.py
+++ b/python/metrics/tests/test_metrics.py
@@ -159,3 +159,4 @@ def test_nash_sutcliffe_efficiency():
     NNSEL = metrics.nash_sutcliffe_efficiency(np.exp(y_true), 
         np.exp(y_pred), log=True, normalized=True)
     assert NNSEL == 0.2
+    print(NNSEL)

--- a/python/metrics/tests/test_metrics.py
+++ b/python/metrics/tests/test_metrics.py
@@ -3,6 +3,7 @@ from evaluation_tools.metrics import metrics
 
 import pandas as pd
 from math import isclose
+import numpy as np
 
 contigency_table = {
     'true_positive': 1,
@@ -17,6 +18,9 @@ alt_contigency_table = {
     'FN': 3,
     'TN': 4
 }
+
+y_true = [1., 2., 3., 4.]
+y_pred = [4., 3., 2., 1.]
 
 def test_compute_contingency_table():
     obs = pd.Categorical([True, False, False, True, True, True,
@@ -132,3 +136,26 @@ def test_equitable_threat_score():
         true_negative_key='TN'
         )
     assert isclose(ETS, (-0.2/4.8), abs_tol=0.000001)
+
+def test_mean_squared_error():
+    MSE = metrics.mean_squared_error(y_true, y_pred)
+    assert MSE == 5.0
+
+    RMSE = metrics.mean_squared_error(y_true, y_pred, root=True)
+    assert RMSE == np.sqrt(5.0)
+
+def test_nash_sutcliffe_efficiency():
+    NSE = metrics.nash_sutcliffe_efficiency(y_true, y_pred)
+    assert NSE == -3.0
+    
+    NNSE = metrics.nash_sutcliffe_efficiency(y_true, y_pred, 
+        normalized=True)
+    assert NNSE == 0.2
+    
+    NSEL = metrics.nash_sutcliffe_efficiency(np.exp(y_true), 
+        np.exp(y_pred), log=True)
+    assert NSEL == -3.0
+    
+    NNSEL = metrics.nash_sutcliffe_efficiency(np.exp(y_true), 
+        np.exp(y_pred), log=True, normalized=True)
+    assert NNSEL == 0.2

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ MAINTAINER = "Austin Raney"
 MAINTAINER_EMAIL = "arthur.raney@noaa.gov"
 
 # Namespace package version
-VERSION = "1.3.4+1"
+VERSION = "1.3.5+1"
 URL = "https://github.com/NOAA-OWP/evaluation_tools"
 
 # Map subpackage namespace to relative location


### PR DESCRIPTION
This add mean squared error and nash-suttcliffe efficiency to the `metrics` package. These tools are in a format compatible with `sklearn` and potentially other packages used to calibrate, test, and validate models. The methods can also be used alone to generate model evaluation statistics.

## Additions

- `mean_squared_error` and `nash_suttcliffe_effiency` methods

## Removals

- None

## Changes

- Added two new methods and tests

## Testing

1. Tests base functionality of each method, as well as additional RMSE, NSE long, and NNSE functionality.


## Notes

- `numpy` *array_like* type hints require `numpy>=1.20`

## Todos

- These methods see additional parameters in the future to reflect different statistical options.
- NSE could include a `bounded` parameter to offer an alternative method of "normalization"
- Skill scores like NSE follow the same general format. We could refactor later into a more generic skill score format

## Checklist

- [x] PR has an informative and human-readable title
- [x] PR is well outlined and documented. See [#12](https://github.com/jarq6c/evaluation_tools/pull/12) for an example
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output) using [numpy docstring](https://numpydoc.readthedocs.io/en/latest/format.html) formatting
- [ ] Placeholder code is flagged / future todos are captured in comments
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
